### PR TITLE
feat: Filter Orders to sync and misc: wrong fieldname map

### DIFF
--- a/woocommerce_integration/general_utils.py
+++ b/woocommerce_integration/general_utils.py
@@ -52,10 +52,26 @@ def build_filter_string(filters: dict) -> str:
     """
     Build a filter string from a dict for the WooCommerce API.
     """
+
+    def clean_value(value):
+        return (
+            ",".join(value)
+            if isinstance(
+                value,
+                (
+                    list,
+                    tuple,
+                ),
+            )
+            else value
+        )
+
     if not filters:
         return ""
 
-    return "&".join([f"{key}={value}" for key, value in filters.items() if value])
+    return "&".join(
+        [f"{key}={clean_value(value)}" for key, value in filters.items() if value]
+    )
 
 
 def log_woocommerce_error(response: dict):

--- a/woocommerce_integration/order_creation_utils.py
+++ b/woocommerce_integration/order_creation_utils.py
@@ -67,7 +67,7 @@ def create_address(raw_data: dict, customer: dict, address_type: str):
         {
             "pincode": raw_data.get("postcode"),
             "address_line1": raw_data.get("address_1", "Not Provided"),
-            "woocomm_customer_id": customer.woocommerce_id,
+            "woocomm_customer_id": customer.woocomm_customer_id,
             "address_type": address_type,
         },
     ):
@@ -77,7 +77,7 @@ def create_address(raw_data: dict, customer: dict, address_type: str):
     address.address_line1 = raw_data.get("address_1", "Not Provided")
     address.address_line2 = raw_data.get("address_2")
     address.city = raw_data.get("city", "Not Provided")
-    address.woocomm_customer_id = customer.woocommerce_id
+    address.woocomm_customer_id = customer.woocomm_customer_id
     address.address_type = address_type
     address.state = raw_data.get("state")
     address.pincode = raw_data.get("postcode")
@@ -104,7 +104,7 @@ def create_contact(data: dict, customer: str):
         "Contact",
         {
             "email_id": email,
-            "woocomm_customer_id": customer.woocommerce_id,
+            "woocomm_customer_id": customer.woocomm_customer_id,
         },
     ):
         return
@@ -113,7 +113,7 @@ def create_contact(data: dict, customer: str):
     contact.first_name = data.get("first_name")
     contact.last_name = data.get("last_name")
     contact.email_id = email
-    contact.woocomm_customer_id = customer.woocommerce_id
+    contact.woocomm_customer_id = customer.woocomm_customer_id
     contact.is_primary_contact = 1
     contact.is_billing_contact = 1
 

--- a/woocommerce_integration/woocommerce/doctype/woocommerce_order_status/woocommerce_order_status.json
+++ b/woocommerce_integration/woocommerce/doctype/woocommerce_order_status/woocommerce_order_status.json
@@ -1,0 +1,32 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-04-22 16:39:10.381579",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "pending\nprocessing\non-hold\ncompleted\ncancelled\nrefunded\nfailed\ntrash"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-04-22 16:39:24.847406",
+ "modified_by": "Administrator",
+ "module": "WooCommerce",
+ "name": "WooCommerce Order Status",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/woocommerce_integration/woocommerce/doctype/woocommerce_order_status/woocommerce_order_status.py
+++ b/woocommerce_integration/woocommerce/doctype/woocommerce_order_status/woocommerce_order_status.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WooCommerceOrderStatus(Document):
+    pass

--- a/woocommerce_integration/woocommerce/doctype/woocommerce_setup/woocommerce_setup.json
+++ b/woocommerce_integration/woocommerce/doctype/woocommerce_setup/woocommerce_setup.json
@@ -43,7 +43,9 @@
   "column_break_zht3a",
   "order_sync_frequency",
   "order_sync_interval",
-  "order_server_script"
+  "order_server_script",
+  "filters_section",
+  "order_status"
  ],
  "fields": [
   {
@@ -282,12 +284,23 @@
    "fieldname": "order_per_page",
    "fieldtype": "Int",
    "label": "Orders Per Page"
+  },
+  {
+   "fieldname": "filters_section",
+   "fieldtype": "Section Break",
+   "label": "Filters"
+  },
+  {
+   "fieldname": "order_status",
+   "fieldtype": "Table",
+   "label": "Order status",
+   "options": "WooCommerce Order Status"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-04-04 16:28:49.151443",
+ "modified": "2024-04-22 16:53:51.604167",
  "modified_by": "Administrator",
  "module": "WooCommerce",
  "name": "WooCommerce Setup",

--- a/woocommerce_integration/woocommerce/doctype/woocommerce_setup/woocommerce_setup.py
+++ b/woocommerce_integration/woocommerce/doctype/woocommerce_setup/woocommerce_setup.py
@@ -11,6 +11,10 @@ from woocommerce_integration.general_utils import get_woocommerce_setup
 
 
 class WooCommerceSetup(Document):
+    @property
+    def order_status_filters(self):
+        return [row.status for row in self.order_status]
+
     def onload(self):
         series = (
             frappe.get_meta("Sales Order").get_options("naming_series") or "SO-WOO-"

--- a/woocommerce_integration/woocommerce/sync_utils.py
+++ b/woocommerce_integration/woocommerce/sync_utils.py
@@ -76,7 +76,9 @@ def get_woocommerce_orders():
     orders = []
 
     order_response = woocommerce.get_orders(
-        modified_after=last_sync_datetime, per_page=per_page
+        per_page=per_page,
+        modified_after=last_sync_datetime,
+        status=setup.order_status_filters,
     )
 
     orders.extend(order_response.json())
@@ -84,7 +86,10 @@ def get_woocommerce_orders():
 
     for page_idx in range(1, pages):
         order_response = woocommerce.get_orders(
-            page=page_idx + 1, per_page=per_page, modified_after=last_sync_datetime
+            page=page_idx + 1,
+            per_page=per_page,
+            modified_after=last_sync_datetime,
+            status=setup.order_status_filters,
         )
         orders.extend(order_response.json())
 


### PR DESCRIPTION
- Allow users to select which statuses the orders should be filtered by and fetched from WooComm
  <img width="1166" alt="Screenshot 2024-04-22 at 7 09 38 PM" src="https://github.com/alyf-de/woocommerce_integration/assets/25857446/91b59d9b-edf6-4720-b01f-de50b69a5cbf">
- Also make `build_filter_string` accomodate for iterable filter arguments
- misc: Woocomm customer id not set in Address and Contact

