### PR TITLE
fix: Get orders ordered by `modified` `ascending` and use store most recent modified date

### DIFF
--- a/woocommerce_integration/general_utils.py
+++ b/woocommerce_integration/general_utils.py
@@ -54,7 +54,7 @@ def update_woocommerce_sync(field: str, date_time: str | datetime):
     if isinstance(date_time, str):
         date_time = get_datetime(date_time)
 
-    frappe.db.set_value("WooCommerce Setup", None, field, date_time)
+    frappe.db.set_single_value("WooCommerce Setup", field, date_time)
 
 
 def log_woocommerce_error(response: dict):

--- a/woocommerce_integration/general_utils.py
+++ b/woocommerce_integration/general_utils.py
@@ -1,11 +1,13 @@
 import base64
 import hashlib
 import json
+from datetime import datetime
 from hmac import new as HMAC
 from typing import Optional, Tuple
 
 import frappe
 from frappe import _
+from frappe.utils import get_datetime
 
 
 def get_woocommerce_setup():
@@ -46,6 +48,13 @@ def process_request_data() -> Tuple[bool, Optional[dict]]:
         return (True, None) if "webhook_id" in order else (False, json.loads(order))
 
     return False, order
+
+
+def update_woocommerce_sync(field: str, date_time: str | datetime):
+    if isinstance(date_time, str):
+        date_time = get_datetime(date_time)
+
+    frappe.db.set_value("WooCommerce Setup", None, field, date_time)
 
 
 def log_woocommerce_error(response: dict):


### PR DESCRIPTION
- Earlier `last_order_sync` was incorrectly set to **now**
- Util `update_woocommerce_sync `